### PR TITLE
"vcd_vapp_vm" Module Release 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This Terraform module will deploy Virtual Machines into an existing Virtual Appl
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.2 |
-| vcd | ~> 3.8 |
+| terraform | ~> 1.5 |
+| vcd | ~> 3.9 |
 
 This Module depends on a vApp already being created in your Virtual Data Center. You can use the [vcd_vapp](https://github.com/global-vmware/vcd_vapp) Module to create the vApp that will be used to provision your VMs into.
 
@@ -18,6 +18,7 @@ This Module depends on a vApp already being created in your Virtual Data Center.
 | [vcd_vdc_group](https://registry.terraform.io/providers/vmware/vcd/latest/docs/data-sources/vdc_group) | data source |
 | [vcd_nsxt_edgegateway](https://registry.terraform.io/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) | data source |
 | [vcd_network_routed_v2](https://registry.terraform.io/providers/vmware/vcd/latest/docs/data-sources/network_routed_v2) | data source |
+| [vcd_network_isolated_v2](https://registry.terraform.io/providers/vmware/vcd/latest/docs/data-sources/network_isolated_v2) | data source |
 | [vcd_vm_sizing_policy](https://registry.terraform.io/providers/vmware/vcd/latest/docs/data-sources/vm_sizing_policy) | data source |
 | [vcd_catalog](https://registry.terraform.io/providers/vmware/vcd/latest/docs/data-sources/catalog) | data source |
 | [vcd_catalog_vapp_template](https://registry.terraform.io/providers/vmware/vcd/latest/docs/data-sources/catalog_vapp_template) | data source |
@@ -34,7 +35,7 @@ This Module depends on a vApp already being created in your Virtual Data Center.
 | vdc_name | Cloud Director VDC Name | string | `"Virtual Data Center Name Format: <Account_Number>-<Region>-<Segment Name>"` | Yes |
 | vcd_edge_name | Name of the Data Center Group Edge Gateway | string | `"Edge Gateway Name Format: <Account_Number>-<Region>-<Edge_GW_Identifier>-<edge>"` | Yes |
 | vm_sizing_policy_name | Cloud Director VM Sizing Policy Name | string | "gp2.4" | no |
-| vapp_org_networks | List of vApp Org network names | list(object({ name = string })) | [] | yes |
+| vapp_org_networks | List of vApp Org networks (type can equal "routed" or "isolated") | list(object({ name = string, type = string })) | [] | yes |
 | is_fenced | Allows identical virtual machines in different vApp networks to connect to Organization VDC Networks that are accessed in this vApp. | bool | `false` | no |
 | retain_ip_mac_enabled | Specifies whether the network resources such as IP/MAC of router will be retained across deployments. Configurable when is_fenced is true. | bool | `false` | no |
 | reboot_vapp_on_removal | VCD 10.4.1+ API prohibits removal of vApp network from a powered on vApp. Set to true to power off the vApp during vApp network removal. If the vApp's original state was powered on, it will be powered back on after removing the network | bool | `true` | no |
@@ -113,9 +114,10 @@ module "vcd_vapp_vm" {
   vm_count                          = 2
 
   vapp_name                         = "My Production Application"
+
   vapp_org_networks                 = [
-    { name = "US1-Segment-01" },
-    { name = "US1-Segment-02" },
+    { name = "US1-Segment-01", type = "routed" },
+    { name = "US1-Segment-02", type = "routed" }
   ]
 
   vm_name                           = ["Production App Web Server"]

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ data "vcd_vapp" "vapp" {
 data "vcd_vapp_org_network" "vappOrgNet" {
   for_each          = { for net in var.vapp_org_networks : net.name => net }
   org               = var.vdc_org_name
+  vdc               = var.vdc_name
   vapp_name         = data.vcd_vapp.vapp.name
   org_network_name  = each.value.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,11 +28,12 @@ variable "vm_sizing_policy_name" {
 }
 
 variable "vapp_org_networks" {
-  description = "List of vApp Org network names"
-  type        = list(object({
-    name      = string
+  description = "List of Org networks with their types"
+  type = list(object({
+    name = string
+    type = string
   }))
-  default     = []
+  default = []
 }
 
 variable "is_fenced" {

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "vm_sizing_policy_name" {
 }
 
 variable "vapp_org_networks" {
-  description = "List of Org networks with their types"
+  description = "List of vApp Org networks with their types"
   type = list(object({
     name = string
     type = string


### PR DESCRIPTION
- "vcd_vapp_vm" Module Release 2.3.0

- Added the "vcd_network_isolated_v2" data source to dynamically choose between routed or isolated networks based on the network type specified in the "vapp_org_networks" variable

- Updated the "vapp_org_networks" variable to specify the network type for each org network (routed or isolated)

- Updated the Inputs Section in the README to include the changes to the "vapp_org_networks" variable

- Updated the Example Code Section in the README to include the "type" of vapp_org_network in the Code Snippet